### PR TITLE
Add details-table directive for outputting a custom table for attributes

### DIFF
--- a/carbon_theme/static/style.css
+++ b/carbon_theme/static/style.css
@@ -1071,9 +1071,11 @@ footer span.commit code {
     color: #444;
 }
 
+.details-table td.details-table-name,
 .details-table tr:first-of-type td:first-of-type {
-    font-weight: bold;
     color: #283037;
+    text-align: right;
+    font-weight: bold;
 }
 
 .function .details-table tr:first-of-type td:last-of-type {


### PR DESCRIPTION
This directive includes several parameters:

* :required: -- for required fields
* :type: -- type of object. This field will resolve as a reference

The nested content is output as the ``description`` field in the table, if there
is any content.